### PR TITLE
ajusta campo professor de cadastro turma com nova funcionalidade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1806,66 +1806,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/register": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.22.5.tgz",
-      "integrity": "sha512-vV6pm/4CijSQ8Y47RH5SopXzursN35RQINfGJkmOlcpAtGuf94miFvIPhCKGQN7WGIcsgG1BHEX2KVdTYwTwUQ==",
-      "peer": true,
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "find-cache-dir": "^2.0.0",
-        "make-dir": "^2.1.0",
-        "pirates": "^4.0.5",
-        "source-map-support": "^0.5.16"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/register/node_modules/make-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-      "peer": true,
-      "dependencies": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@babel/register/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/@babel/register/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@babel/register/node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "peer": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "node_modules/@babel/runtime": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
@@ -13139,53 +13079,6 @@
         "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/helper-validator-option": "^7.18.6",
         "@babel/plugin-transform-typescript": "^7.18.6"
-      }
-    },
-    "@babel/register": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.22.5.tgz",
-      "integrity": "sha512-vV6pm/4CijSQ8Y47RH5SopXzursN35RQINfGJkmOlcpAtGuf94miFvIPhCKGQN7WGIcsgG1BHEX2KVdTYwTwUQ==",
-      "peer": true,
-      "requires": {
-        "clone-deep": "^4.0.1",
-        "find-cache-dir": "^2.0.0",
-        "make-dir": "^2.1.0",
-        "pirates": "^4.0.5",
-        "source-map-support": "^0.5.16"
-      },
-      "dependencies": {
-        "make-dir": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-          "peer": true,
-          "requires": {
-            "pify": "^4.0.1",
-            "semver": "^5.6.0"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "peer": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "peer": true
-        },
-        "source-map-support": {
-          "version": "0.5.21",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-          "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-          "peer": true,
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
-          }
-        }
       }
     },
     "@babel/runtime": {

--- a/src/pages/turmas/turmas.tsx
+++ b/src/pages/turmas/turmas.tsx
@@ -1,4 +1,4 @@
-import React, { SyntheticEvent, useContext, useState } from "react";
+import React, { SyntheticEvent, useContext, useEffect, useState } from "react";
 import styled from "styled-components";
 import Sidebar from "../../shared/components/Sidebar/sidebar";
 import Navbarlog from "../../shared/components/NavbarLogada/navbarLogada";
@@ -32,6 +32,7 @@ import { FormProvider, useForm } from "react-hook-form";
 import { TurmasListarDTO } from "./dtos/TurmasListar.dto";
 import { TurmasDTO } from "./dtos/Turmas.dto";
 import { TurmasCadastrarDTO } from "./dtos/TurmasCadastrar.dto";
+import { ProfessoresCadastrarDTO } from "../professores/dtos/ProfessoresCadastrar.dto";
 import { VagasListarDTO } from "./dtos/VagasListar.dto";
 import { GridActionsCellItem, GridRowId, DataGrid } from "@mui/x-data-grid";
 import {
@@ -63,6 +64,7 @@ import { parse, compareAsc } from "date-fns";
 import { AiFillEdit } from "react-icons/ai";
 import { excluirAssistente } from "../../services/assistentes";
 import { AuthContext } from "../../context/AuthProvider";
+import { listaProfessores } from "../../services/professores";
 
 const Container = styled.div`
   width: 100%;
@@ -152,6 +154,9 @@ export function Turmas(this: any) {
   const [open, setOpen] = useState(false);
   const [turma, setTurma] = useState(Object);
   const [alunaSelecionada, setAlunaSelecionada] = useState(Object);
+  const [professores, setProfessores] = useState(Array<string>);
+  const [professor, setProfessor] = React.useState<string | null>(null);
+  const [inputValue, setInputValue] = React.useState('');
   const [id, setId] = useState<GridRowId>(0);
   const [codigoTurma, setcodigoTurma] = useState<GridRowId>(0);
   const [codigoRegister, setCodigoRegister] = useState<GridRowId>(0);
@@ -202,7 +207,7 @@ export function Turmas(this: any) {
     const turma = {
       codigo: data.codigo,
       fk_curso: data.fk_curso,
-      fk_professor: data.fk_professor,
+      fk_professor: professor,
       nome_turma: data.nome_turma,
       capacidade_turma: data.capacidade_turma,
       inicio_aula: data.inicio_aula,
@@ -609,7 +614,25 @@ export function Turmas(this: any) {
     { field: "fim_aula", headerName: "Horário de Término", width: 180 },
     { field: "data_inicio", headerName: "Data de Início", width: 165 },
     { field: "data_fim", headerName: "Data de Término", width: 165 },
+  
   ];
+
+  const getProfessores = async () => {
+
+    const response = await listaProfessores();
+    const professoresApi:ProfessoresCadastrarDTO[]= response.data
+    const menuItemProfessores = professoresApi.map((professor:ProfessoresCadastrarDTO) => {
+      return professor.nome
+      
+    });
+
+    setProfessores(menuItemProfessores)
+
+  }
+  
+  useEffect(()=>{
+     getProfessores()
+  },[])
 
   return (
     <Container>
@@ -705,13 +728,30 @@ export function Turmas(this: any) {
               <ValueMask label="inicio_aula" />
               <ValueMask label="fim_aula" />
 
-              <TextField
+              <Autocomplete
+                value={professor}
+                onChange={(event: any, newValue: string | null) => {
+                  setProfessor(newValue);
+                }}
+                inputValue={inputValue}
+                onInputChange={(event, newInputValue) => {
+                  setInputValue(newInputValue);
+                }}
+                disablePortal
+                id="combo-box-demo"
+                options={professores}
+                sx={{ width: "100%", background: "#F5F4FF" }}
+                renderInput={(params) => <TextField {...params} label="Professor" />}
+              />
+
+              {/* <TextField
                 id="outlined-professor"
                 required={true}
                 label="Professor"
                 {...register("fk_professor")}
                 sx={{ width: "100%", background: "#F5F4FF" }}
-              />
+              /> */}
+
               <TextField
                 id="outlined-descricao"
                 label="Descrição"
@@ -737,6 +777,7 @@ export function Turmas(this: any) {
               {...register("nomeTurmaEdit")}
               sx={{ width: "100%", background: "#F5F4FF" }}
             />
+
             {/* <TextField
               id="outlined-descricao"
               label="Descrição"
@@ -744,6 +785,7 @@ export function Turmas(this: any) {
               {...register("descricaoTurmaEdit")}
               sx={{ width: "100%", background: "#F5F4FF" }}
             /> */}
+
             <TextField
               id="outlined-capacidade_turma"
               label="Número de vagas"


### PR DESCRIPTION
# Descrição

Anteriormente aos ajustes realizados, era possível cadastrar turma, mas não era feita uma listagem de professores já cadastrados para serem atribuídos as turmas que são cadastradas.

# Mudanças

* Altera o tipo de input do campo de atribuição de professor para o cadastro de uma turma;
* O campo para atribuição de um professor recebe um autocomplete para a seleção;
* Autocomplete ligado aos professores cadastrados no banco.

# Issue
 Faz alterações relevantes que contribuem para [US09] Cadastrar turma. (Issue #12)
